### PR TITLE
fix: add gc in onNextUpdate to prevent possible leak

### DIFF
--- a/packages/rearch/lib/src/node.dart
+++ b/packages/rearch/lib/src/node.dart
@@ -27,6 +27,8 @@ abstract class DataflowGraphNode implements Disposable {
     _dependencies.clear();
   }
 
+  bool get hasNoDependents => _dependents.isEmpty;
+
   void buildSelfAndDependents() {
     // We must build self, so we preemptively build it before other checks
     final selfChanged = buildSelf();


### PR DESCRIPTION
Previously, if an inline capsule was used inside a `Widget`, it may not have been disposed when the `Widget` was disposed. Now, `onNextUpdate` will eagerly try to garbage collect its supplied capsule when possible to prevent any such leaks (which should cover 99% of situations).