### PR TITLE
Added `loadingInfo` field to `AsyncLoading`

### DIFF
--- a/examples/count_warm_up/lib/main.dart
+++ b/examples/count_warm_up/lib/main.dart
@@ -80,7 +80,8 @@ class GlobalWarmUps extends RearchConsumer {
       // other warm ups here...
     ].toWarmUpWidget(
       child: child,
-      loading: const Center(child: CircularProgressIndicator.adaptive()),
+      loadingBuilder: (info) =>
+          const Center(child: CircularProgressIndicator.adaptive()),
       errorBuilder: (errors) => Column(
         children: [
           // You might want your error display here to be prettier than this.

--- a/packages/flutter_rearch/example/lib/main.dart
+++ b/packages/flutter_rearch/example/lib/main.dart
@@ -158,7 +158,8 @@ final class GlobalWarmUps extends RearchConsumer {
       use(indexWarmUpCapsule),
     ].toWarmUpWidget(
       child: child,
-      loading: const Center(child: CircularProgressIndicator.adaptive()),
+      loadingBuilder: (info) =>
+          const Center(child: CircularProgressIndicator.adaptive()),
       errorBuilder: (errors) => Column(
         children: [
           for (final AsyncError(:error, :stackTrace) in errors)

--- a/packages/flutter_rearch/lib/src/widgets/capsule_warm_up.dart
+++ b/packages/flutter_rearch/lib/src/widgets/capsule_warm_up.dart
@@ -7,12 +7,12 @@ extension CapsuleWarmUp<T> on List<AsyncValue<T>> {
   /// some "warm up" [Capsule]s.
   ///
   /// - [child] is returned when all of the current states are [AsyncData].
-  /// - [loading] is returned when any of the current states are [AsyncLoading].
+  /// - [loadingBuilder] is returned when any of the current states are [AsyncLoading].
   /// - [errorBuilder] is called to build the returned [Widget] when any
   /// of the current states are [AsyncError].
   Widget toWarmUpWidget({
     required Widget Function(List<AsyncError<T>>) errorBuilder,
-    required Widget loading,
+    required Widget Function(Object? loadingInfo) loadingBuilder,
     required Widget child,
   }) {
     // Check for any errors first
@@ -23,7 +23,9 @@ extension CapsuleWarmUp<T> on List<AsyncValue<T>> {
 
     // Check to see if we have any still loading
     if (any((value) => value is AsyncLoading<T>)) {
-      return loading;
+      final asyncLoading =
+          firstWhere((value) => value is AsyncLoading<T>) as AsyncLoading<T>;
+      return loadingBuilder(asyncLoading.loadingInfo);
     }
 
     // We have only AsyncData (no loading or error), so return the child

--- a/packages/rearch/lib/src/types.dart
+++ b/packages/rearch/lib/src/types.dart
@@ -164,12 +164,16 @@ final class AsyncData<T> extends AsyncValue<T> {
 @immutable
 final class AsyncLoading<T> extends AsyncValue<T> {
   /// Creates an [AsyncLoading] with the supplied [previousData].
-  const AsyncLoading(this.previousData);
+  const AsyncLoading(this.previousData, [this.loadingInfo]);
 
   /// The previous data (from a predecessor [AsyncData]), if it exists.
   /// This can happen if a new [Future]/[Stream] is watched and the
   /// [Future]/[Stream] it is replacing was in the [AsyncData] state.
   final Option<T> previousData;
+
+  /// Optional object info, typically a String that describes the current
+  /// loading state.
+  final Object? loadingInfo;
 
   @override
   int get hashCode => previousData.hashCode;
@@ -179,7 +183,8 @@ final class AsyncLoading<T> extends AsyncValue<T> {
       other is AsyncLoading<T> && other.previousData == previousData;
 
   @override
-  String toString() => 'AsyncLoading(previousData: $previousData)';
+  String toString() => 'AsyncLoading(previousData: $previousData'
+      '${loadingInfo == null ? '' : ', loadingInfo: ${loadingInfo!}'})';
 }
 
 /// The error variant for an [AsyncValue].

--- a/packages/rearch/lib/src/types.dart
+++ b/packages/rearch/lib/src/types.dart
@@ -175,6 +175,9 @@ final class AsyncLoading<T> extends AsyncValue<T> {
   /// loading state.
   final Object? loadingInfo;
 
+  /// Returns [loadingInfo] object casted to [Q].
+  Q getLoadingInfo<Q extends Object?>() => loadingInfo as Q;
+
   @override
   int get hashCode => previousData.hashCode;
 


### PR DESCRIPTION
It's an optional object info, typically a String that describes the current loading state.
Could be useful when warming up capsules to show a text describing the loading state along side with a loading spinner.