### PR TITLE
feat: add use.data and use.lazyData side effects

### DIFF
--- a/packages/flutter_rearch/lib/src/side_effects.dart
+++ b/packages/flutter_rearch/lib/src/side_effects.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_rearch/flutter_rearch.dart';
-import 'package:rearch/experimental.dart';
 import 'package:rearch/rearch.dart';
 
 part 'side_effects/animation.dart';

--- a/packages/flutter_rearch/lib/src/side_effects/keep_alive.dart
+++ b/packages/flutter_rearch/lib/src/side_effects/keep_alive.dart
@@ -16,7 +16,7 @@ void _automaticKeepAlive(
 
   // Dirty tracks whether or not we will need to request a new keep alive
   // in case keepAlive == true
-  final (getDirty, setDirty) = use.rawValueWrapper(() => true);
+  final (getDirty, setDirty) = use.data(true);
   final requestKeepAlive = use.memo(
     () => () {
       // It is only safe to dispatch a notification when dirty is true

--- a/packages/rearch/lib/experimental.dart
+++ b/packages/rearch/lib/experimental.dart
@@ -9,25 +9,10 @@ library experimental;
 import 'package:meta/meta.dart';
 import 'package:rearch/rearch.dart';
 
-extension _UseConvenience on SideEffectRegistrar {
-  SideEffectRegistrar get use => this;
-}
+// extension _UseConvenience on SideEffectRegistrar {
+//   SideEffectRegistrar get use => this;
+// }
 
 /// A collection of experimental side effects to
 /// complement the [BuiltinSideEffects].
-extension ExperimentalSideEffects on SideEffectRegistrar {
-  /// Returns a raw value wrapper; i.e., a getter and setter for some value.
-  /// *The setter will not trigger rebuilds*.
-  /// The initial state will be set to the result of running [init],
-  /// if it was provided. Otherwise, you must manually set it
-  /// via the setter before ever calling the getter.
-  // NOTE: experimental because I am not sold on the API and use cases
-  // for non-internal usage.
-  (T Function(), void Function(T)) rawValueWrapper<T>([T Function()? init]) {
-    return use.callonce(() {
-      late T state;
-      if (init != null) state = init();
-      return (() => state, (T newState) => state = newState);
-    });
-  }
-}
+extension ExperimentalSideEffects on SideEffectRegistrar {}


### PR DESCRIPTION
Removes the previously experimental `use.rawValueWrapper` side effect.
If you were using this side effect, simply migrate to `use.lazyData`.

Fixes #127 