### PR TITLE
fix: remove erroneous markNeedsBuild call in use.automaticKeepAlive

### DIFF
--- a/packages/flutter_rearch/test/side_effects_test.dart
+++ b/packages/flutter_rearch/test/side_effects_test.dart
@@ -362,4 +362,49 @@ void main() {
 
     await tester.pumpAndSettle();
   });
+
+  testWidgets('automatic keep alive can be deactivated (#199)', (tester) async {
+    await tester.pumpWidget(
+      RearchBootstrapper(
+        child: MaterialApp(
+          home: RearchBuilder(
+            builder: (context, use) {
+              final switchedPage = use.data(false);
+
+              if (switchedPage.value) {
+                return const Text('No assert!');
+              }
+
+              return CustomScrollView(
+                slivers: [
+                  SliverList.list(
+                    children: List.generate(50, (index) {
+                      return RearchBuilder(
+                        builder: (context, use) {
+                          use.automaticKeepAlive();
+                          return SizedBox(
+                            width: 600,
+                            height: 200,
+                            child: TextButton(
+                              onPressed: () => switchedPage.value = true,
+                              child: Text('switch $index'),
+                            ),
+                          );
+                        },
+                      );
+                    }),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('switch 0'));
+    await tester.pump();
+
+    expect(find.text('No assert!'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Fixes #199 by switching out `use.data` for a non-rebuilding alternative
(so that `markNeedsBuild` isn't called in `deactivate`).