### PR TITLE
fix: ensure widget is mounted before marking dirty

### DIFF
--- a/packages/flutter_rearch/lib/src/widgets/consumer.dart
+++ b/packages/flutter_rearch/lib/src/widgets/consumer.dart
@@ -148,7 +148,7 @@ class _WidgetSideEffectApiProxyImpl implements WidgetSideEffectApi {
       if (isCanceled) return;
     }
 
-    manager.markNeedsBuild();
+    if (manager.mounted) manager.markNeedsBuild();
   }
 
   @override


### PR DESCRIPTION
Fixes #304