### PR TITLE
feat(experimental): tighten dynamic capsule disposal semantics and orphan cleanup

### DIFF
--- a/packages/rearch/lib/experimental.dart
+++ b/packages/rearch/lib/experimental.dart
@@ -8,6 +8,7 @@ library;
 
 import 'package:meta/meta.dart';
 import 'package:rearch/rearch.dart';
+import 'package:rearch/src/node.dart';
 
 extension _UseConvenience on SideEffectRegistrar {
   SideEffectRegistrar get use => this;
@@ -45,9 +46,20 @@ extension ExperimentalSideEffects on SideEffectRegistrar {
   /// If what you are trying to do doesn't fit into one of the above categories,
   /// do _not_ use [dynamic]. Instead, write your code in a different way.
   DynamicOrchestrator<Param, Return> dynamic<Param, Return>(
-    Return Function(CapsuleHandle, Param) dyn,
+    Return Function(
+      CapsuleHandle,
+      Param,
+      // Manual disposal is restricted:
+      // - It is only allowed when there are no dependents.
+      // - It is not allowed during any ongoing capsule build.
+      void Function() disposeSelf,
+    )
+    dyn,
+    void Function(Param) onDispose,
   ) {
-    return use.lazyValue(() => DynamicOrchestrator._(dyn));
+    return use.lazyValue(
+      () => DynamicOrchestrator._(dyn, onDispose: onDispose),
+    );
   }
 }
 
@@ -57,16 +69,77 @@ extension ExperimentalSideEffects on SideEffectRegistrar {
 /// There is currently no publicly available API on this class;
 /// instead, use [DynamicCapsuleAccess] to read a dynamic capsule.
 final class DynamicOrchestrator<Param, Return> {
-  DynamicOrchestrator._(this._dyn);
-  final Return Function(CapsuleHandle, Param) _dyn;
+  DynamicOrchestrator._(this._dyn, {void Function(Param)? onDispose})
+    : _onDispose = onDispose;
+  final Return Function(
+    CapsuleHandle,
+    Param,
+    void Function() disposeSelf,
+  )
+  _dyn;
+  final void Function(Param)? _onDispose;
   final Map<Param, Capsule<Return>> _capsules = {};
+  final Map<Param, DataflowGraphNode> _nodes = {};
 
   Capsule<Return> _get(Param param) {
     return _capsules.putIfAbsent(param, () {
       return (CapsuleHandle handle) {
-        return _dyn(handle, param);
+        final api = handle.api();
+        final node = api as DataflowGraphNode;
+
+        handle.callonce(() {
+          _nodes[param] = node;
+          api.registerDispose(() => _evictParam(param));
+        });
+
+        void disposeSelf() {
+          if (!dispose(param)) {
+            throw DynamicCapsuleDisposeBlockedError(param);
+          }
+        }
+
+        return _dyn(handle, param, disposeSelf);
       };
     });
+  }
+
+  /// Attempts to manually dispose the dynamic capsule at [param].
+  ///
+  /// Returns true when disposal succeeds (or the capsule was already absent),
+  /// and false when disposal is blocked by existing dependents.
+  bool dispose(Param param) {
+    final capsule = _capsules[param];
+    if (capsule == null) return true;
+
+    final node = _nodes[param];
+    if (node != null) {
+      final didDispose = node.disposeIfNoDependents();
+      if (!didDispose) return false;
+    }
+
+    _evictParam(param);
+    _onDispose?.call(param);
+    return true;
+  }
+
+  void _evictParam(Param param) {
+    _capsules.remove(param);
+    _nodes.remove(param);
+  }
+}
+
+/// Thrown when a dynamic capsule manual disposal is blocked by dependents.
+final class DynamicCapsuleDisposeBlockedError<Param> extends Error {
+  /// Creates a blocked-disposal error for [param].
+  DynamicCapsuleDisposeBlockedError(this.param);
+
+  /// The dynamic capsule parameter that failed to dispose.
+  final Param param;
+
+  @override
+  String toString() {
+    return 'DynamicCapsuleDisposeBlockedError: cannot manually dispose '
+        'dynamic capsule with param $param while it still has dependents';
   }
 }
 
@@ -126,9 +199,15 @@ extension DynamicCapsuleCreationConvenience on CapsuleCreationConvenience {
   /// NOTE: I'd recommend specifying the return type under all situations
   /// regardless, as it'll increase code reability.
   DynamicCapsule<Param, Return> dynamic<Param, Return>(
-    Return Function(CapsuleHandle, Param) dyn,
+    Return Function(
+      CapsuleHandle,
+      Param,
+      void Function() disposeSelf,
+    )
+    dyn,
+    void Function(Param) onDispose,
   ) {
-    return (CapsuleHandle use) => use.dynamic(dyn);
+    return (CapsuleHandle use) => use.dynamic(dyn, onDispose);
   }
 }
 

--- a/packages/rearch/lib/experimental.dart
+++ b/packages/rearch/lib/experimental.dart
@@ -80,6 +80,7 @@ final class DynamicOrchestrator<Param, Return> {
   final void Function(Param)? _onDispose;
   final Map<Param, Capsule<Return>> _capsules = {};
   final Map<Param, DataflowGraphNode> _nodes = {};
+  final Set<Param> _didCallOnDispose = {};
 
   Capsule<Return> _get(Param param) {
     return _capsules.putIfAbsent(param, () {
@@ -88,8 +89,9 @@ final class DynamicOrchestrator<Param, Return> {
         final node = api as DataflowGraphNode;
 
         handle.callonce(() {
+          _didCallOnDispose.remove(param);
           _nodes[param] = node;
-          api.registerDispose(() => _evictParam(param));
+          api.registerDispose(() => _finalizeDisposed(param));
         });
 
         void disposeSelf() {
@@ -117,9 +119,15 @@ final class DynamicOrchestrator<Param, Return> {
       if (!didDispose) return false;
     }
 
-    _evictParam(param);
-    _onDispose?.call(param);
+    _finalizeDisposed(param);
     return true;
+  }
+
+  void _finalizeDisposed(Param param) {
+    _evictParam(param);
+    if (_didCallOnDispose.contains(param)) return;
+    _didCallOnDispose.add(param);
+    _onDispose?.call(param);
   }
 
   void _evictParam(Param param) {

--- a/packages/rearch/lib/rearch.dart
+++ b/packages/rearch/lib/rearch.dart
@@ -108,6 +108,7 @@ abstract interface class SideEffectApi {
 /// See the documentation for more.
 class CapsuleContainer implements Disposable {
   final _capsules = <_UntypedCapsule, _CapsuleManager>{};
+  final _orphanedNodesToTryDispose = <DataflowGraphNode>{};
 
   /// Non-null indicates we are currently in a transaction,
   /// with the side effect mutations to call in the [List].
@@ -134,12 +135,35 @@ class CapsuleContainer implements Disposable {
     sideEffectTransaction();
 
     if (isRootTxn) {
-      final managersToRebuild = _sideEffectMutationsToCallInTxn!
-          .map((mutation) => mutation())
-          .nonNulls
-          .toSet();
-      DataflowGraphNode.buildNodesAndDependents(managersToRebuild);
-      _sideEffectMutationsToCallInTxn = null;
+      try {
+        final managersToRebuild = _sideEffectMutationsToCallInTxn!
+            .map((mutation) => mutation())
+            .nonNulls
+            .toSet();
+        DataflowGraphNode.buildNodesAndDependents(managersToRebuild);
+        _disposeQueuedOrphans();
+      } finally {
+        _sideEffectMutationsToCallInTxn = null;
+      }
+    }
+  }
+
+  void _queueDetachedDependenciesForCleanup(
+    Iterable<DataflowGraphNode> dependencies,
+  ) {
+    _orphanedNodesToTryDispose.addAll(dependencies);
+  }
+
+  void _disposeQueuedOrphans() {
+    while (_orphanedNodesToTryDispose.isNotEmpty) {
+      final toCheck = _orphanedNodesToTryDispose.toList();
+      _orphanedNodesToTryDispose.clear();
+
+      for (final node in toCheck) {
+        if (node.isIdempotent) {
+          node.disposeIfNoDependents();
+        }
+      }
     }
   }
 

--- a/packages/rearch/lib/src/impl.dart
+++ b/packages/rearch/lib/src/impl.dart
@@ -40,11 +40,19 @@ class _CapsuleManager extends DataflowGraphNode
     final parentBuildingManager = container._currBuildingManager;
     container._currBuildingManager = this;
     try {
+      final oldDependencies = dependenciesSnapshot;
+
       // Clear dependency relationships as they will be repopulated via `read`
       clearDependencies();
 
       // Build the capsule's new data
       final newData = capsule(_CapsuleHandleImpl(this));
+
+      final detachedDependencies = oldDependencies.difference(
+        dependenciesSnapshot,
+      );
+      container._queueDetachedDependenciesForCleanup(detachedDependencies);
+
       final didChange = !hasBuilt || newData != data;
       data = newData;
       hasBuilt = true;
@@ -56,6 +64,21 @@ class _CapsuleManager extends DataflowGraphNode
 
   @override
   bool get isIdempotent => sideEffectData.isEmpty;
+
+  @override
+  bool disposeIfNoDependents() {
+    final currBuildingManager = container._currBuildingManager;
+    assert(
+      currBuildingManager == null,
+      'You are not allowed to dispose a capsule within an ongoing build! '
+      'This likely happened because you called disposeSelf() during a '
+      'capsule build. '
+      'See here for more: '
+      'https://rearch.gsconrad.com/core/effects#transactions',
+    );
+
+    return super.disposeIfNoDependents();
+  }
 
   @override
   void dispose() {

--- a/packages/rearch/lib/src/node.dart
+++ b/packages/rearch/lib/src/node.dart
@@ -27,6 +27,14 @@ abstract class DataflowGraphNode implements Disposable {
 
   bool get hasNoDependents => _dependents.isEmpty;
 
+  Set<DataflowGraphNode> get dependenciesSnapshot => {..._dependencies};
+
+  bool disposeIfNoDependents() {
+    if (!hasNoDependents) return false;
+    dispose();
+    return true;
+  }
+
   static void buildNodesAndDependents(Set<DataflowGraphNode> nodes) {
     final buildOrderStack = _createBuildOrderStack(nodes);
     final disposableNodes = _getDisposableNodesFromBuildOrderStack(

--- a/packages/rearch/test/dynamic_capsules_test.dart
+++ b/packages/rearch/test/dynamic_capsules_test.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:rearch/experimental.dart';
+import 'package:rearch/rearch.dart';
+
+void main() {
+  CapsuleContainer().read(bootAppCapsule);
+}
+
+void bootAppCapsule(CapsuleHandle use) {
+  final index = use.data(0);
+
+  use.effect(() {
+    return Timer.periodic(const Duration(seconds: 10), (_) {
+      index.value++;
+    }).cancel;
+  });
+
+  use(customIndexDynamicCapsules[index.value]);
+}
+
+final DynamicCapsule<int, String> customIndexDynamicCapsules = capsule
+    .dynamic<int, String>(
+      (use, index, disposeSelf) {
+        final count = use.data(0);
+
+        use.effect(() {
+          return Timer.periodic(const Duration(seconds: 2), (_) {
+            print('<$index>: Count: ${count.value++}');
+            if (count.value == 10) {
+              disposeSelf();
+            }
+          }).cancel;
+        });
+
+        return 'Index $index';
+      },
+      (index) {
+        print('Disposed $index');
+      },
+    );

--- a/packages/rearch/test/side_effects_test.dart
+++ b/packages/rearch/test/side_effects_test.dart
@@ -493,14 +493,14 @@ void main() {
     // NOTE: due to a Dart type system quirk (relating only to local variables),
     // this has to be written with `late final` and defined on a new line.
     late final DynamicCapsule<int, BigInt> fibonacciCapsule;
-    fibonacciCapsule = capsule.dynamic((use, int n) {
+    fibonacciCapsule = capsule.dynamic((use, int n, _) {
       return switch (n) {
         _ when n < 0 => throw ArgumentError.value(n),
         0 => BigInt.zero,
         1 => BigInt.one,
         _ => use(fibonacciCapsule[n - 1]) + use(fibonacciCapsule[n - 2]),
       };
-    });
+    }, (_) {});
 
     test('allow correct creation of fibonacci numbers', () {
       expect(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -515,10 +515,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -539,10 +539,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -992,26 +992,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.17"
   toml:
     dependency: transitive
     description:


### PR DESCRIPTION
- Implement graph-aware manual disposal for dynamic capsules with strict guards: disposal only succeeds when the target has no dependents.
- Enforce disposal-time build restriction: disposeSelf is not allowed during an ongoing capsule build.
- Add orphan dependency cleanup after transaction rebuild sweeps so detached idempotent wrapper capsules are disposed promptly.
- Support strict outside disposal by tracking dynamic param → node mappings and using node-level dependent checks.
- Keep orchestrator caches consistent by evicting dynamic entries on manager disposal.