### PR TITLE
refactor: eagerly capture CapsuleContainer in transactionRunner

### DIFF
--- a/packages/flutter_rearch/lib/src/widgets/consumer.dart
+++ b/packages/flutter_rearch/lib/src/widgets/consumer.dart
@@ -173,17 +173,9 @@ class _WidgetSideEffectApiProxyImpl implements WidgetSideEffectApi {
   void unregisterDispose(SideEffectApiCallback callback) =>
       manager.disposeListeners.remove(callback);
 
-  /// [rebuild] just marks the corresponding widget as dirty,
-  /// so all affected widgets will be built together on the next frame for free.
-  /// Thus, all we need to do is update all the capsules in a single txn
-  /// before the widgets are built again.
-  /// This works out somewhat nicely, as we can easily intermingle
-  /// widget and capsule side effects within a single transaction.
   @override
-  void runTransaction(void Function() sideEffectTransaction) =>
-      CapsuleContainerProvider.containerOf(
-        manager,
-      ).runTransaction(sideEffectTransaction);
+  CapsuleContainer get container =>
+      CapsuleContainerProvider.containerOf(manager);
 }
 
 class _WidgetHandleImpl implements WidgetHandle {

--- a/packages/rearch/lib/rearch.dart
+++ b/packages/rearch/lib/rearch.dart
@@ -97,11 +97,8 @@ abstract interface class SideEffectApi {
   /// from being called on capsule disposal.
   void unregisterDispose(SideEffectApiCallback callback);
 
-  /// Executes the supplied [sideEffectTransaction],
-  /// which simply updates the state of some side effects
-  /// within a singular rebuild call,
-  /// rebuilding all appropriate capsules at the conclusion of the transaction.
-  void runTransaction(void Function() sideEffectTransaction);
+  /// The [CapsuleContainer] associated with this side effect API.
+  CapsuleContainer get container;
 }
 
 /// Contains the data of [Capsule]s.

--- a/packages/rearch/lib/src/impl.dart
+++ b/packages/rearch/lib/src/impl.dart
@@ -8,6 +8,7 @@ class _CapsuleManager extends DataflowGraphNode
     buildSelf();
   }
 
+  @override
   final CapsuleContainer container;
   final _UntypedCapsule capsule;
 
@@ -103,10 +104,6 @@ class _CapsuleManager extends DataflowGraphNode
   @override
   void unregisterDispose(SideEffectApiCallback callback) =>
       toDispose.remove(callback);
-
-  @override
-  void runTransaction(void Function() sideEffectTransaction) =>
-      container.runTransaction(sideEffectTransaction);
 }
 
 class _CapsuleHandleImpl implements CapsuleHandle {

--- a/packages/rearch/lib/src/side_effects.dart
+++ b/packages/rearch/lib/src/side_effects.dart
@@ -21,9 +21,13 @@ extension BuiltinSideEffects on SideEffectRegistrar {
   rebuilder() => use.api().rebuild;
 
   /// Convenience side effect that gives a copy of
-  /// [SideEffectApi.runTransaction].
-  void Function(void Function()) transactionRunner() =>
-      use.api().runTransaction;
+  /// [CapsuleContainer.runTransaction].
+  void Function(void Function()) transactionRunner() {
+    final api = use.api();
+    final container = use.callonce(() => api.container);
+
+    return container.runTransaction;
+  }
 
   /// Side effect that calls the supplied [callback] once, on the first build.
   T callonce<T>(T Function() callback) => use.register((_) => callback());


### PR DESCRIPTION
The Flutter implementation of `runTransaction` looked up the `CapsuleContainer` from the widget tree on every invocation via `CapsuleContainerProvider.containerOf(manager)`. This fails if the consumer widget has already been unmounted.

Fix by exposing `CapsuleContainer` directly from `SideEffectApi` and having `transactionRunner()` capture it once at registration time (via `callonce`), keeping the container alive for later use.

- Remove `runTransaction` from `SideEffectApi`
- Add `CapsuleContainer get container` to `SideEffectApi`
- Drop stale overrides from `_CapsuleManager` and `_WidgetSideEffectApiProxyImpl`
- Rewire `transactionRunner()` through `api.container`
- Clean up commented-out declarations and doc references