### PR TITLE
feat(rearch): add experimental ephemeral capsules

### DIFF
--- a/packages/rearch/lib/experimental.busslina.dart
+++ b/packages/rearch/lib/experimental.busslina.dart
@@ -1,0 +1,75 @@
+/// Experimental ephemeral capsules for ReArch.
+///
+/// Nothing here is officially supported;
+/// items may come and go or experience breaking changes on any new release.
+/// Further, items here may be untested so use at your own risk!
+@experimental
+library;
+
+import 'package:meta/meta.dart';
+import 'package:rearch/rearch.dart';
+
+extension _UseConvenience on SideEffectRegistrar {
+  SideEffectRegistrar get use => this;
+}
+
+/// Builds the value for an ephemeral capsule instance.
+typedef EphemeralBuilder<Param, Return> =
+    Return Function(EphemeralCapsuleHandle use, Param param);
+
+/// A parameterized ephemeral capsule.
+typedef EphemeralCapsule<Param, Return> =
+    Capsule<EphemeralOrchestrator<Param, Return>>;
+
+/// A launch predicate for [EphemeralCapsuleReader.readEphemeral].
+typedef EphemeralLaunchPredicate = bool Function(int life);
+
+/// Provides ephemeral capsule orchestration as a side effect.
+extension EphemeralSideEffects on SideEffectRegistrar {
+  /// Allows you to construct parameterized ephemeral capsules.
+  ///
+  /// Ephemeral capsules are launched explicitly via
+  /// [EphemeralCapsuleReader.readEphemeral]. Reading their state never launches
+  /// them unless the supplied launch predicate returns true.
+  EphemeralOrchestrator<Param, Return> ephemeral<Param, Return>(
+    EphemeralBuilder<Param, Return> builder,
+  ) {
+    return use.register((api) => EphemeralOrchestrator(api, builder));
+  }
+}
+
+/// This is public so that you may define your own extensions on [capsule].
+typedef CapsuleCreationConvenience = Capsule<T> Function<T>(Capsule<T>);
+
+/// Provides [ephemeral].
+extension EphemeralCapsuleCreationConvenience on CapsuleCreationConvenience {
+  /// Shorthand for a fully formed ephemeral capsule.
+  ///
+  /// Basic usage:
+  /// ```dart
+  /// final myEphemeral = capsule.ephemeral((use, id) {
+  ///   return MyResource(onDone: use.dispose);
+  /// });
+  /// ```
+  EphemeralCapsule<Param, Return> ephemeral<Param, Return>(
+    EphemeralBuilder<Param, Return> builder,
+  ) {
+    return (CapsuleHandle use) => use.ephemeral(builder);
+  }
+}
+
+/// Allows you to read and optionally launch ephemeral capsules.
+extension EphemeralCapsuleReader on CapsuleReader {
+  /// Reads the current ephemeral state for [param].
+  ///
+  /// If the state is inactive, [launch] is called with the next launch
+  /// generation for [param]. Returning true launches the ephemeral instance;
+  /// returning false leaves it inactive.
+  Ephemeral<Return> readEphemeral<Param, Return>(
+    EphemeralCapsule<Param, Return> capsule,
+    Param param,
+    EphemeralLaunchPredicate launch,
+  ) {
+    return call(capsule).read(param, launch);
+  }
+}

--- a/packages/rearch/lib/rearch.dart
+++ b/packages/rearch/lib/rearch.dart
@@ -10,6 +10,7 @@ export 'src/types.dart';
 
 part 'src/impl.dart';
 part 'src/capsule_warm_up.dart';
+part 'src/ephemeral_capsule.dart';
 
 /// Represents a disposable object.
 // ignore: one_member_abstracts
@@ -108,18 +109,23 @@ abstract interface class SideEffectApi {
 /// See the documentation for more.
 class CapsuleContainer implements Disposable {
   final _capsules = <_UntypedCapsule, _CapsuleManager>{};
+  final _ephemeralManagers = <DataflowGraphNode>{};
 
   /// Non-null indicates we are currently in a transaction,
   /// with the side effect mutations to call in the [List].
   /// When null, we are not in a transaction and we must make one for rebuilds.
   /// Side effect mutations return their _CapsuleManager when it should
   /// be rebuilt, and null when the side effect state wasn't updated.
-  List<_CapsuleManager? Function()>? _sideEffectMutationsToCallInTxn;
+  List<_BuildManager? Function()>? _sideEffectMutationsToCallInTxn;
+
+  final _changedNodesToNotify = <DataflowGraphNode>{};
+
+  int _buildDepth = 0;
 
   /// The currently building [_CapsuleManager].
   /// Needed so we can check whether a rebuild called within a build is valid;
   /// i.e., whether the rebuild was called within its own capsule's build.
-  _CapsuleManager? _currBuildingManager;
+  _BuildManager? _currBuildingManager;
 
   /// Runs the supplied [sideEffectTransaction] that combines all side effect
   /// state updates into a single container rebuild sweep.
@@ -140,14 +146,31 @@ class CapsuleContainer implements Disposable {
           .toSet();
       DataflowGraphNode.buildNodesAndDependents(managersToRebuild);
       _sideEffectMutationsToCallInTxn = null;
+      _flushChangedNodeNotifications();
+    }
+  }
+
+  void _notifyNodeChanged(DataflowGraphNode node) {
+    if (_buildDepth > 0 || _sideEffectMutationsToCallInTxn != null) {
+      _changedNodesToNotify.add(node);
+      return;
+    }
+
+    DataflowGraphNode.notifyNodesChanged({node});
+  }
+
+  void _flushChangedNodeNotifications() {
+    if (_buildDepth > 0 || _sideEffectMutationsToCallInTxn != null) return;
+
+    while (_changedNodesToNotify.isNotEmpty) {
+      final changedNodes = {..._changedNodesToNotify};
+      _changedNodesToNotify.clear();
+      DataflowGraphNode.notifyNodesChanged(changedNodes);
     }
   }
 
   _CapsuleManager _managerOf(_UntypedCapsule capsule) {
-    return _capsules.putIfAbsent(
-      capsule,
-      () => _CapsuleManager(this, capsule),
-    );
+    return _capsules.putIfAbsent(capsule, () => _CapsuleManager(this, capsule));
   }
 
   /// Reads the current data of the supplied [Capsule],
@@ -222,6 +245,10 @@ class CapsuleContainer implements Disposable {
 
   @override
   void dispose() {
+    for (final manager in _ephemeralManagers.toList()) {
+      manager.dispose();
+    }
+
     // We need toList() to copy the list in order to
     // prevent container modification during iteration
     // (dispose() removes the manager from the container).

--- a/packages/rearch/lib/src/ephemeral_capsule.dart
+++ b/packages/rearch/lib/src/ephemeral_capsule.dart
@@ -1,0 +1,325 @@
+part of '../rearch.dart';
+
+/// The observable state of an ephemeral capsule.
+@experimental
+sealed class Ephemeral<T> {
+  /// Creates an ephemeral state.
+  const Ephemeral();
+
+  /// The lifecycle generation represented by this state.
+  ///
+  /// For active states, this is the active instance generation. For inactive
+  /// states, this is the generation the next launch will use.
+  int get life;
+
+  /// Whether this state is active.
+  bool get active;
+
+  /// The active value, or null when this state is inactive.
+  T? get nullableValue => switch (this) {
+    EphemeralInactive() => null,
+    EphemeralActive(:final value) => value,
+  };
+}
+
+/// Indicates that an ephemeral capsule is not currently active.
+@experimental
+@immutable
+final class EphemeralInactive<T> extends Ephemeral<T> {
+  /// Creates an inactive ephemeral state.
+  const EphemeralInactive(this.life);
+
+  @override
+  final int life;
+
+  @override
+  int get hashCode => life.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is EphemeralInactive<T> && other.life == life;
+
+  @override
+  bool get active => false;
+
+  @override
+  String toString() => 'EphemeralInactive(life: $life)';
+}
+
+/// Indicates that an ephemeral capsule is currently active with [value].
+@experimental
+@immutable
+final class EphemeralActive<T> extends Ephemeral<T> {
+  /// Creates an active ephemeral state with [value].
+  const EphemeralActive(this.value, this.life);
+
+  /// The current value returned by the active ephemeral capsule.
+  final T value;
+
+  @override
+  final int life;
+
+  @override
+  int get hashCode => Object.hash(value, life);
+
+  @override
+  bool operator ==(Object other) =>
+      other is EphemeralActive<T> && other.value == value && other.life == life;
+
+  @override
+  bool get active => true;
+
+  @override
+  String toString() => 'EphemeralActive(value: $value, life: $life)';
+}
+
+/// The handle supplied to ephemeral capsules.
+@experimental
+abstract interface class EphemeralCapsuleHandle implements CapsuleHandle {
+  /// The launch generation for this ephemeral capsule instance.
+  ///
+  /// This starts at zero for each parameter and increments every time a launch
+  /// starts, even if that instance disposes during its initial build.
+  int get life;
+
+  /// Disposes the current ephemeral capsule.
+  ///
+  /// If called while the ephemeral capsule is building, disposal is completed
+  /// synchronously as soon as that build exits.
+  void dispose();
+}
+
+/// Coordinates a parameterized set of ephemeral capsule instances.
+@experimental
+final class EphemeralOrchestrator<Param, Return> {
+  /// Creates an ephemeral orchestrator.
+  EphemeralOrchestrator(SideEffectApi api, this._builder)
+    : _owner = _asCapsuleManager(api);
+
+  final Return Function(EphemeralCapsuleHandle, Param) _builder;
+  final _CapsuleManager _owner;
+  final _entries = <Param, _EphemeralEntry<Param, Return>>{};
+
+  /// Reads the current state for [param], optionally launching it.
+  ///
+  /// [launch] receives the next launch generation for [param], starting at
+  /// zero. Returning true launches the ephemeral instance when it is inactive;
+  /// returning false keeps it inactive.
+  Ephemeral<Return> read(Param param, bool Function(int life) launch) {
+    return _read(param, launch);
+  }
+
+  Ephemeral<Return> _read(Param param, bool Function(int life) launch) {
+    final entry = _entryOf(param);
+    if (entry.manager != null) return entry.state;
+    if (!launch(entry.lives)) return entry.state;
+
+    final manager = _EphemeralManager<Param, Return>(this, param, entry.lives);
+    entry
+      ..lives += 1
+      ..manager = manager;
+
+    try {
+      manager.buildSelf();
+    } catch (_) {
+      manager.dispose();
+      rethrow;
+    }
+
+    return entry.state;
+  }
+
+  _EphemeralEntry<Param, Return> _entryOf(Param param) {
+    return _entries.putIfAbsent(param, _EphemeralEntry<Param, Return>.new);
+  }
+
+  void _markActive(
+    Param param,
+    _EphemeralManager<Param, Return> manager,
+    Return value,
+  ) {
+    final entry = _entryOf(param);
+    final newState = EphemeralActive(value, manager.life);
+    if (identical(entry.manager, manager) && entry.state == newState) return;
+
+    entry
+      ..manager = manager
+      ..state = newState;
+    _owner.container._notifyNodeChanged(_owner);
+  }
+
+  void _markInactive(Param param, _EphemeralManager<Param, Return> manager) {
+    final entry = _entryOf(param);
+    if (!identical(entry.manager, manager)) return;
+
+    entry.manager = null;
+    final newState = EphemeralInactive<Return>(entry.lives);
+    if (entry.state == newState) return;
+
+    entry.state = newState;
+    _owner.container._notifyNodeChanged(_owner);
+  }
+
+  static _CapsuleManager _asCapsuleManager(SideEffectApi api) {
+    if (api case final _CapsuleManager manager) return manager;
+
+    throw ArgumentError.value(
+      api,
+      'api',
+      'EphemeralOrchestrator must be created from a capsule side effect.',
+    );
+  }
+}
+
+final class _EphemeralEntry<Param, Return> {
+  int lives = 0;
+  late Ephemeral<Return> state = EphemeralInactive<Return>(lives);
+  _EphemeralManager<Param, Return>? manager;
+}
+
+final class _EphemeralManager<Param, Return> extends _BuildManager {
+  _EphemeralManager(this.orchestrator, this.param, this.life) {
+    container._ephemeralManagers.add(this);
+  }
+
+  final EphemeralOrchestrator<Param, Return> orchestrator;
+  final Param param;
+  final int life;
+
+  @override
+  CapsuleContainer get container => orchestrator._owner.container;
+
+  Return? value;
+  bool hasBuilt = false;
+  bool isDisposed = false;
+  bool _isBuilding = false;
+  bool _disposeRequested = false;
+  @override
+  final List<Object?> sideEffectData = <Object?>[];
+  final toDispose = <SideEffectApiCallback>{};
+
+  @override
+  bool buildSelf() {
+    if (isDisposed) return false;
+
+    final parentBuildingManager = container._currBuildingManager;
+    container._currBuildingManager = this;
+    container._buildDepth++;
+    _isBuilding = true;
+    try {
+      clearDependencies();
+
+      final newValue = orchestrator._builder(
+        _EphemeralCapsuleHandleImpl(this),
+        param,
+      );
+      if (_disposeRequested) return false;
+
+      final didChange = !hasBuilt || newValue != value;
+      value = newValue;
+      hasBuilt = true;
+      if (didChange) {
+        orchestrator._markActive(param, this, newValue);
+      }
+      return didChange;
+    } finally {
+      _isBuilding = false;
+      container._buildDepth--;
+      container._currBuildingManager = parentBuildingManager;
+      if (_disposeRequested && !isDisposed) {
+        _disposeNow();
+      }
+      container._flushChangedNodeNotifications();
+    }
+  }
+
+  @override
+  bool get isIdempotent => false;
+
+  @override
+  // The real cleanup path is _disposeNow, which calls super.dispose(). When
+  // disposal is requested during build, cleanup must wait until build exits.
+  // ignore: must_call_super
+  void dispose() {
+    if (isDisposed || _disposeRequested) return;
+
+    _disposeRequested = true;
+    if (_isBuilding) return;
+
+    _disposeNow();
+  }
+
+  void _disposeNow() {
+    if (isDisposed) return;
+    isDisposed = true;
+
+    container._ephemeralManagers.remove(this);
+    super.dispose();
+    for (final callback in toDispose.toList()) {
+      callback();
+    }
+    toDispose.clear();
+    sideEffectData.clear();
+    orchestrator._markInactive(param, this);
+  }
+
+  @override
+  R read<R>(Capsule<R> otherCapsule) {
+    final otherManager = container._managerOf(otherCapsule);
+    addDependency(otherManager);
+    return otherManager.data as R;
+  }
+
+  @override
+  void rebuild([
+    void Function(void Function() cancelRebuild)? sideEffectMutation,
+  ]) {
+    if (isDisposed) return;
+
+    if (container._currBuildingManager != null) {
+      assert(
+        container._currBuildingManager == this,
+        'You are not allowed to trigger rebuilds within an ongoing build of a '
+        'different capsule or ephemeral capsule!',
+      );
+
+      sideEffectMutation?.call(() {});
+      return;
+    }
+
+    container.runTransaction(() {
+      container._sideEffectMutationsToCallInTxn!.add(() {
+        if (isDisposed) return null;
+
+        var isCanceled = false;
+        sideEffectMutation?.call(() => isCanceled = true);
+        return isCanceled || isDisposed ? null : this;
+      });
+    });
+  }
+
+  @override
+  void registerDispose(SideEffectApiCallback callback) =>
+      toDispose.add(callback);
+
+  @override
+  void unregisterDispose(SideEffectApiCallback callback) =>
+      toDispose.remove(callback);
+
+  @override
+  void runTransaction(void Function() sideEffectTransaction) =>
+      container.runTransaction(sideEffectTransaction);
+}
+
+final class _EphemeralCapsuleHandleImpl extends _CapsuleHandleImpl
+    implements EphemeralCapsuleHandle {
+  _EphemeralCapsuleHandleImpl(this.ephemeralManager) : super(ephemeralManager);
+
+  final _EphemeralManager<dynamic, dynamic> ephemeralManager;
+
+  @override
+  int get life => ephemeralManager.life;
+
+  @override
+  void dispose() => ephemeralManager.dispose();
+}

--- a/packages/rearch/lib/src/impl.dart
+++ b/packages/rearch/lib/src/impl.dart
@@ -2,20 +2,31 @@ part of '../rearch.dart';
 
 typedef _UntypedCapsule = Capsule<Object?>;
 
-class _CapsuleManager extends DataflowGraphNode
-    implements SideEffectApi, Disposable {
+abstract class _BuildManager extends DataflowGraphNode
+    implements SideEffectApi {
+  CapsuleContainer get container;
+
+  List<Object?> get sideEffectData;
+
+  R read<R>(Capsule<R> otherCapsule);
+}
+
+class _CapsuleManager extends _BuildManager implements Disposable {
   _CapsuleManager(this.container, this.capsule) {
     buildSelf();
   }
 
+  @override
   final CapsuleContainer container;
   final _UntypedCapsule capsule;
 
   late Object? data;
   bool hasBuilt = false;
-  final sideEffectData = <Object?>[];
+  @override
+  final List<Object?> sideEffectData = <Object?>[];
   final toDispose = <SideEffectApiCallback>{};
 
+  @override
   R read<R>(Capsule<R> otherCapsule) {
     if (otherCapsule == capsule) {
       if (hasBuilt) {
@@ -39,6 +50,7 @@ class _CapsuleManager extends DataflowGraphNode
   bool buildSelf() {
     final parentBuildingManager = container._currBuildingManager;
     container._currBuildingManager = this;
+    container._buildDepth++;
     try {
       // Clear dependency relationships as they will be repopulated via `read`
       clearDependencies();
@@ -50,7 +62,9 @@ class _CapsuleManager extends DataflowGraphNode
       hasBuilt = true;
       return didChange;
     } finally {
+      container._buildDepth--;
       container._currBuildingManager = parentBuildingManager;
+      container._flushChangedNodeNotifications();
     }
   }
 
@@ -112,7 +126,7 @@ class _CapsuleManager extends DataflowGraphNode
 class _CapsuleHandleImpl implements CapsuleHandle {
   _CapsuleHandleImpl(this.manager);
 
-  final _CapsuleManager manager;
+  final _BuildManager manager;
 
   int sideEffectDataIndex = 0;
 

--- a/packages/rearch/lib/src/node.dart
+++ b/packages/rearch/lib/src/node.dart
@@ -54,6 +54,31 @@ abstract class DataflowGraphNode implements Disposable {
     }
   }
 
+  static void notifyNodesChanged(Set<DataflowGraphNode> nodes) {
+    final buildOrderStack = _createBuildOrderStack(nodes);
+    final disposableNodes = _getDisposableNodesFromBuildOrderStack(
+      buildOrderStack,
+    );
+    final changedNodes = {...nodes};
+
+    for (final node in buildOrderStack.reversed) {
+      if (nodes.contains(node)) continue;
+
+      final haveDepsChanged = node._dependencies.any(changedNodes.contains);
+      if (!haveDepsChanged) continue;
+
+      if (disposableNodes.contains(node)) {
+        node.dispose();
+        changedNodes.add(node);
+      } else {
+        final didNodeChange = node.buildSelf();
+        if (didNodeChange) {
+          changedNodes.add(node);
+        }
+      }
+    }
+  }
+
   static List<DataflowGraphNode> _createBuildOrderStack(
     Set<DataflowGraphNode> start,
   ) {


### PR DESCRIPTION
Add experimental ephemeral capsules with explicit launch semantics and observable lifecycle state.

- Add experimental.busslina.dart with capsule.ephemeral and readEphemeral APIs
- Introduce EphemeralActive/EphemeralInactive state with lifecycle generation
- Add EphemeralCapsuleHandle with life and dispose support
- Add internal ephemeral managers that participate in the dataflow graph
- Ensure disposal clears dependencies, runs side-effect disposers, and notifies observers
- Generalize build-manager handling so capsules and ephemeral managers share reads, side effects, and rebuilds
- Add synchronous changed-node notification support for orchestrator state changes
- Dispose active ephemeral managers when the container is disposed